### PR TITLE
Migrate to web-push v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,10 +1893,11 @@ checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-push"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "890ba149bd4a7f6a30d7396b5cdbfc9fadb9e1da2ca04fbc62f7b550d842e56e"
+checksum = "30bdf799b4be6f04bfee94807548718de568834c9ea020e73b59af3dac66d72c"
 dependencies = [
+ "async-trait",
  "base64",
  "chrono",
  "ece",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ log = "0.4"
 hyper-tls = { version = "0.5", features = ["vendored"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
-web-push = { version = "0.9", features = ["hyper-client"], default-features = false }
+web-push = { version = "0.10", features = ["hyper-client"], default-features = false }


### PR DESCRIPTION
This is the current maintainer of rust-web-push - v0.10.0 made some breaking changes, so I figured I would migrate this crate to use them to enable future security fixes. There should be no runtime difference, as this was entirely a refactor.